### PR TITLE
Fix arcnav drawer

### DIFF
--- a/src/style/main.scss
+++ b/src/style/main.scss
@@ -26,9 +26,18 @@
     color: #4990e2;
 }
 
-.swagger-ui nav {
+.swagger-ui nav:not(#scrollingNav) {
     position: fixed;
     width: 100%;
     top: 0;
+    z-index: 1000;
+}
+
+.swagger-ui nav:not(#scrollingNav) div > ul:first-of-type img {
+    margin-top: 12px;
+}
+
+.swagger-ui nav:not(#scrollingNav) input[type=search] {
+    padding: .5em .35em .5em 2.4em;
 }
 


### PR DESCRIPTION
There are CSS conflicts between Arcnav and the Swagger UI. Most noticeably, the Arcnav slideout drawer renders below the swagger sidebar. It would be nice if there was a way to isolate the swagger CSS so that it didn't interfere with Arcnav, but that's out of scope for this change.

The changes here aren't perfect -- there are still some font and other styles which slightly change the Arcnav design, but at least it's usable now.